### PR TITLE
fix: 내가 참여한 여행 api 수정 완료 #55

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -92,7 +92,7 @@
         "noDuplicateObjectKeys": "error",
         "noDuplicateParameters": "error",
         "noEmptyBlockStatements": "error",
-        "noExplicitAny": "error",
+        "noExplicitAny": "warn",
         "noExtraNonNullAssertion": "error",
         "noFallthroughSwitchClause": "error",
         "noFunctionAssign": "error",

--- a/src/api/travel/travel.route.ts
+++ b/src/api/travel/travel.route.ts
@@ -254,8 +254,6 @@ travelRouter.get(
         return;
       }
 
-      // const travels = await Travel.find({ bookmark: { $in: [user?._id] } });
-
       const teams = await Team.find({
         appliedUsers: {
           $elemMatch: {
@@ -292,7 +290,7 @@ travelRouter.get(
             approvedMembers: team.appliedUsers.map((user) => {
               return {
                 userId: user.userId._id,
-                mbti: (user.userId as any).mbti,
+                mbti: (user.userId as any).mbti || null,
                 status: user.status,
               };
             }),

--- a/src/api/travel/travel.route.ts
+++ b/src/api/travel/travel.route.ts
@@ -262,19 +262,49 @@ travelRouter.get(
             userId: user._id,
           },
         },
+      })
+        .populate({
+          path: "travelId",
+          select: "travelTitle userId",
+          populate: {
+            path: "userId",
+            select: "socialName userEmail userProfileImage",
+          },
+        })
+        .populate({
+          path: "appliedUsers.userId",
+          select: "mbti socialName",
+        })
+        .lean();
+
+      const travels = teams.map((team) => {
+        return {
+          guideInfo: {
+            socialName: (team.travelId as any).userId.socialName,
+            userProfileImg: (team.travelId as any).userId.userProfileImage,
+            userId: (team.travelId as any).userId._id,
+            userName: (team.travelId as any).userId.userName || null,
+          },
+          travelTeam: {
+            travelStartDate: team.travelStartDate,
+            travelEndDate: team.travelEndDate,
+            personLimit: team.personLimit,
+            approvedMembers: team.appliedUsers.map((user) => {
+              return {
+                userId: user.userId._id,
+                mbti: (user.userId as any).mbti,
+                status: user.status,
+              };
+            }),
+          },
+        };
       });
 
-      const travelIds = teams.map((team) => team.travelId);
-
-      const travels = await Promise.all(
-        travelIds.map(async (travelId) => {
-          return await Travel.findById(travelId).populate("userId").lean();
-        })
-      );
+      console.log(travels);
 
       res.json(
         ResponseDTO.success({
-          travels,
+          travels: travels,
         })
       );
     } catch (error) {


### PR DESCRIPTION
- 내가 참여한 여행 api response 값 수정
- 참여한 사용자의 상태, mbti를 보이게함.

<!-- 변경 사항이나 추가된 기능에 대해 자세히 설명해 주세요. -->

<!-- 주요 변경 사항을 요약해 주세요. -->

<!-- 수정된 화면이나 기능을 보여주는 스크린샷을 첨부할 수 있습니다. -->

<!-- 추가 정보나 특별한 요청 사항이 있다면 여기에 포함해 주세요. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 사용자 여행 관리 및 팀 상호작용과 관련된 기능 개선.
	- `my-travels` 엔드포인트에서 사용자 및 팀 정보가 포함된 상세한 여행 데이터 응답 제공.
	- 여행 팀 세부정보, 여행 날짜 및 구성원 상태를 포함하는 응답 구조 수정.

- **버그 수정**
	- 사용자 존재 여부 및 유효한 ID에 대한 오류 처리 유지.

- **문서화**
	- `biome.json` 파일에서 linter 규칙의 경고 수준 조정.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->