### PR TITLE
Fix 여행 등록 API에서 req.body에 content, title, thumbnail이 있는지 확인하는 로직을 추가함

### DIFF
--- a/src/api/travel/travel.route.ts
+++ b/src/api/travel/travel.route.ts
@@ -7,7 +7,7 @@ import {
 } from "../../checkRequiredFields";
 import { Router } from "express";
 import mongoose from "mongoose";
-import { validObjectId } from "../../validObjectId";
+import { checkIsValidThumbnail, validObjectId } from "../../validChecker";
 
 const getReviewAverage = async (travelId: mongoose.Types.ObjectId) => {
   const reviews = await Review.find({ travelId }).lean();
@@ -40,6 +40,7 @@ travelRouter.get(
   }
 );
 
+
 /**
  * 새로운 여행 계획하기
  * 여행자 모집 글
@@ -51,12 +52,18 @@ travelRouter.post(
     "team",
     "travelTitle",
     "travelContent",
-    "tag",
+    "thumbnail",
     "travelCourse",
     "travelPrice",
   ]),
   async (req, res) => {
     const session = await mongoose.startSession();
+
+    if(!await checkIsValidThumbnail(req.body.thumbnail)) {
+      res.status(400).json(ResponseDTO.fail("Invalid thumbnail URL"));
+      return;
+    }
+
     try {
       session.startTransaction();
       const userId = await User.findById(req.body.userId).lean();

--- a/src/api/travel/travel.route.ts
+++ b/src/api/travel/travel.route.ts
@@ -55,11 +55,12 @@ travelRouter.post(
     "thumbnail",
     "travelCourse",
     "travelPrice",
+    "tag",
   ]),
   async (req, res) => {
     const session = await mongoose.startSession();
 
-    if(!await checkIsValidThumbnail(req.body.thumbnail)) {
+    if(req.body.thumbnail && !await checkIsValidThumbnail(req.body.thumbnail)) {
       res.status(400).json(ResponseDTO.fail("Invalid thumbnail URL"));
       return;
     }

--- a/src/api/travelGuide/travelGuide.route.ts
+++ b/src/api/travelGuide/travelGuide.route.ts
@@ -3,7 +3,7 @@ import { ResponseDTO } from '../../ResponseDTO';
 import { checkRequiredFields, checkRequiredFieldsQuery } from '../../checkRequiredFields';
 import { Router } from 'express';
 import mongoose from 'mongoose';
-import { validObjectId } from '../../validObjectId';
+import { checkIsValidThumbnail, validObjectId } from '../../validChecker';
 
 const travelGuideRouter = Router();
 
@@ -23,6 +23,13 @@ travelGuideRouter.post(
   checkRequiredFields(['team', 'travelTitle', 'travelContent']),
   async (req, res) => {
     const session = await mongoose.startSession();
+
+    if (req.body.thumbnail && !await checkIsValidThumbnail(req.body.thumbnail)) {
+      console.log('thumbnail boolean', Boolean(req.body.thumbnail));
+      res.status(400).json(ResponseDTO.fail('Invalid thumbnail URL'));
+      return;
+    }
+
     try {
       session.startTransaction();
       const userId = await User.findById(req.body.userId).lean();
@@ -35,6 +42,7 @@ travelGuideRouter.post(
           {
             ...req.body,
             userId: userId?._id,
+            travelThumbnail: req.body.travelThumbnail || null,
             createdAt: new Date(),
             updatedAt: new Date(),
           },

--- a/src/validChecker.ts
+++ b/src/validChecker.ts
@@ -1,0 +1,26 @@
+import mongoose from "mongoose";
+
+export const validObjectId = (id: string): boolean => {
+  // Check if the id is a valid ObjectId
+  // 16진수 문자열로 변환된 24바이트의 ObjectId를 검증합니다.
+  return mongoose.Types.ObjectId.isValid(id);
+};
+
+
+export const checkIsValidThumbnail = async (thumbnail: string) => {
+  if(!thumbnail.startsWith("http://") && !thumbnail.startsWith("https://")) {
+    return false;
+  } else if(!thumbnail.endsWith(".jpg") && !thumbnail.endsWith(".jpeg") && !thumbnail.endsWith(".png")) {
+    return false;
+  } 
+  try {
+    const response = await fetch(thumbnail);
+    if (!response.ok) {
+      throw new Error("Invalid thumbnail URL");
+    }
+  } catch (error) {
+    console.error(error);
+    return false;
+  }
+  return true;
+}

--- a/src/validObjectId.ts
+++ b/src/validObjectId.ts
@@ -1,7 +1,0 @@
-import mongoose from "mongoose";
-
-export const validObjectId = (id: string): boolean => {
-  // Check if the id is a valid ObjectId
-  // 16진수 문자열로 변환된 24바이트의 ObjectId를 검증합니다.
-  return mongoose.Types.ObjectId.isValid(id);
-};


### PR DESCRIPTION
- 여행 등록 API의 요청값에  tag가 있는지 확인하게 함 #69
- 썸네일이 존재할 때만 checkIsValidThumbnail 썸네일 체크 로직을
  실행하게함

<!-- 변경 사항이나 추가된 기능에 대해 자세히 설명해 주세요. -->

<!-- 주요 변경 사항을 요약해 주세요. -->

<!-- 수정된 화면이나 기능을 보여주는 스크린샷을 첨부할 수 있습니다. -->

<!-- 추가 정보나 특별한 요청 사항이 있다면 여기에 포함해 주세요. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 여행 및 여행 가이드 생성 시 썸네일 URL 유효성 검사 추가
	- 썸네일 URL의 형식과 접근성을 검증하는 새로운 유효성 검사 로직 도입

- **버그 수정**
	- 잘못된 썸네일 URL로 인한 오류 방지
	- 유효하지 않은 썸네일 URL 입력 시 400 상태 코드로 오류 처리

- **리팩토링**
	- 썸네일 유효성 검사 로직을 중앙화된 유틸리티 함수로 통합
	- 기존 ObjectId 유효성 검사 모듈 통합 및 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->